### PR TITLE
Enable JMX for Cassandra using standard container

### DIFF
--- a/flink-connector-cassandra/src/test/resources/Dockerfile
+++ b/flink-connector-cassandra/src/test/resources/Dockerfile
@@ -1,8 +1,0 @@
-FROM cassandra:4.0.8
-
-ENV LOCAL_JMX no
-COPY jmxremote.password /etc/cassandra/jmxremote.password
-COPY jmxremote.access /etc/cassandra/jmxremote.access
-RUN chown cassandra:cassandra /etc/cassandra/jmxremote.*
-RUN chmod 400 /etc/cassandra/jmxremote.*
-

--- a/flink-connector-cassandra/src/test/resources/jmxremote.access
+++ b/flink-connector-cassandra/src/test/resources/jmxremote.access
@@ -1,1 +1,0 @@
-cassandra readwrite

--- a/flink-connector-cassandra/src/test/resources/jmxremote.password
+++ b/flink-connector-cassandra/src/test/resources/jmxremote.password
@@ -1,1 +1,0 @@
-cassandra cassandra


### PR DESCRIPTION
@echauchot I found some time to check why tests are failing in my environment for https://github.com/apache/flink-connector-cassandra/pull/3. You're on a Linux machine, right?  It turns out it's docker networking (I suppose). The lack of host networking support on Macs prevents the JMX url from working.

Also, reading a bit on the topic (http://thegridman.com/coherence/oracle-coherence-on-docker/#jmx), JMX doesn't work reliably in different environments with mapped ports. There's two options:
- use Cassandras standard JMX port with a fixed port binding (but risking that this port might be used otherwise already)
- or dynamically pick a free port and configure JMX for Cassandra from scratch (without auth) to use that port (again with a fixed port binding).

I just pushed the code here for reference, feel free to use it or discard ...